### PR TITLE
Process rules in batches

### DIFF
--- a/src/Application/ApplicationFileProcessor.php
+++ b/src/Application/ApplicationFileProcessor.php
@@ -16,6 +16,7 @@ use Rector\PhpParser\Parser\ParserErrors;
 use Rector\Reporting\MissConfigurationReporter;
 use Rector\Testing\PHPUnit\StaticPHPUnitEnvironment;
 use Rector\Util\ArrayParametersMerger;
+use Rector\Util\BatchSplitter;
 use Rector\ValueObject\Application\File;
 use Rector\ValueObject\Configuration;
 use Rector\ValueObject\Error\SystemError;
@@ -60,6 +61,13 @@ final class ApplicationFileProcessor
         $filePaths = $this->filesFinder->findFilesInPaths($configuration->getPaths(), $configuration);
         $this->missConfigurationReporter->reportVendorInPaths($filePaths);
         $this->missConfigurationReporter->reportStartWithShortOpenTag();
+
+        $batchSplitter = new BatchSplitter();
+        $filePaths = $batchSplitter->getItemsInBatch(
+            $filePaths,
+            $configuration->getBatchIndex(),
+            $configuration->getBatchTotal()
+        );
 
         // no files found
         if ($filePaths === []) {

--- a/src/Configuration/ConfigurationFactory.php
+++ b/src/Configuration/ConfigurationFactory.php
@@ -41,7 +41,9 @@ final readonly class ConfigurationFactory
             false,
             null,
             false,
-            false
+            false,
+            0,
+            0,
         );
     }
 
@@ -65,11 +67,14 @@ final readonly class ConfigurationFactory
         $isParallel = SimpleParameterProvider::provideBoolParameter(Option::PARALLEL);
         $parallelPort = (string) $input->getOption(Option::PARALLEL_PORT);
         $parallelIdentifier = (string) $input->getOption(Option::PARALLEL_IDENTIFIER);
+        $batchIndex = (int) $input->getOption(Option::BATCH_INDEX);
+        $batchTotal = (int) $input->getOption(Option::BATCH_TOTAL);
         $isDebug = (bool) $input->getOption(Option::DEBUG);
 
-        // using debug disables parallel, so emitting exception is straightforward and easier to debug
+        // using debug disables parallel and batch running, so emitting exception is straightforward and easier to debug
         if ($isDebug) {
             $isParallel = false;
+            $batchTotal = 0;
         }
 
         $memoryLimit = $this->resolveMemoryLimit($input);
@@ -90,6 +95,8 @@ final readonly class ConfigurationFactory
             $memoryLimit,
             $isDebug,
             $isReportingWithRealPath,
+            $batchIndex,
+            $batchTotal,
         );
     }
 

--- a/src/Configuration/Option.php
+++ b/src/Configuration/Option.php
@@ -185,6 +185,16 @@ final class Option
     public const PARALLEL_PORT = 'port';
 
     /**
+     * @var string
+     */
+    public const BATCH_INDEX = 'batch-index';
+
+    /**
+     * @var string
+     */
+    public const BATCH_TOTAL = 'batch-total';
+
+    /**
      * @internal Use @see \Rector\Config\RectorConfig::parallel() instead with pass int $jobSize parameter
      * @var string
      */

--- a/src/Console/Command/ProcessCommand.php
+++ b/src/Console/Command/ProcessCommand.php
@@ -83,6 +83,12 @@ EOF
         }
 
         $configuration = $this->configurationFactory->createFromInput($input);
+
+        if ($configuration->getBatchTotal() !== 0 && $configuration->getBatchIndex() >= $configuration->getBatchTotal()) {
+            $this->symfonyStyle->error('The job index needs to be less than the job total');
+            return ExitCode::FAILURE;
+        }
+
         $this->memoryLimiter->adjust($configuration);
 
         // disable console output in case of json output formatter

--- a/src/Console/ConsoleApplication.php
+++ b/src/Console/ConsoleApplication.php
@@ -129,6 +129,20 @@ final class ConsoleApplication extends Application
             InputOption::VALUE_NONE,
             'Clear cache'
         ));
+
+        $inputDefinition->addOption(new InputOption(
+            Option::BATCH_INDEX,
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Index of the current job when running in batch mode'
+        ));
+
+        $inputDefinition->addOption(new InputOption(
+            Option::BATCH_TOTAL,
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Total number of jobs when running in batch mode'
+        ));
     }
 
     private function getDefaultConfigPath(): string

--- a/src/Util/BatchSplitter.php
+++ b/src/Util/BatchSplitter.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Util;
+
+final class BatchSplitter
+{
+    /**
+     * @template T
+     * @param T[] $items
+     * @return T[]
+     */
+    public function getItemsInBatch(array $items, int $batchIndex, int $batchTotal): array
+    {
+        if ($batchTotal !== 0 && $batchIndex < $batchTotal) {
+            $numItems = count($items);
+            $chunkSize = (int) ceil($numItems / $batchTotal);
+            if ($chunkSize > 0) {
+                $chunks = array_chunk($items, $chunkSize);
+                $items = $chunks[$batchIndex] ?? [];
+            }
+        }
+
+        return $items;
+    }
+}

--- a/src/ValueObject/Configuration.php
+++ b/src/ValueObject/Configuration.php
@@ -26,7 +26,9 @@ final readonly class Configuration
         private bool $isParallel = false,
         private string|null $memoryLimit = null,
         private bool $isDebug = false,
-        private bool $reportingWithRealPath = false
+        private bool $reportingWithRealPath = false,
+        private int $batchIndex = 0,
+        private int $batchTotal = 0,
     ) {
     }
 
@@ -100,5 +102,15 @@ final readonly class Configuration
     public function isReportingWithRealPath(): bool
     {
         return $this->reportingWithRealPath;
+    }
+
+    public function getBatchIndex(): int
+    {
+        return $this->batchIndex;
+    }
+
+    public function getBatchTotal(): int
+    {
+        return $this->batchTotal;
     }
 }

--- a/tests/Util/BatchSplitterTest.php
+++ b/tests/Util/BatchSplitterTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\Util;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Rector\Util\BatchSplitter;
+
+final class BatchSplitterTest extends AbstractLazyTestCase
+{
+    private BatchSplitter $batchSplitter;
+
+    protected function setUp(): void
+    {
+        $this->batchSplitter = $this->make(BatchSplitter::class);
+    }
+
+    /**
+     * @param int[] $items
+     * @param int[] $expectedItems
+     */
+    #[DataProvider('provideData')]
+    public function testGetItemsInBatch(
+        array $items,
+        int $batchIndex,
+        int $batchTotal,
+        array $expectedItems
+    ): void {
+        $batchItems = $this->batchSplitter->getItemsInBatch($items, $batchIndex, $batchTotal);
+        $this->assertSame($expectedItems, $batchItems);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [[], 1, 4, []];
+        yield [[1, 2, 3, 4], 0, 0, [1, 2, 3, 4]];
+        yield [[1, 2, 3, 4], 3, 2, [1, 2, 3, 4]];
+        yield [[1, 2, 3, 4], 0, 2, [1, 2]];
+        yield [[1, 2, 3, 4], 1, 2, [3, 4]];
+        yield [[1, 2, 3], 0, 2, [1, 2]];
+        yield [[1, 2, 3], 1, 2, [3]];
+        yield [[1, 2, 3, 4], 0, 3, [1, 2]];
+        yield [[1, 2, 3, 4], 1, 3, [3, 4]];
+        yield [[1, 2, 3, 4], 2, 3, []];
+        yield [[1, 2, 3], 0, 4, [1]];
+        yield [[1, 2, 3], 3, 4, []];
+    }
+}


### PR DESCRIPTION
If you are running Rector in CI or if you have several machines available to run it and you have a large code base, you may want to split processing of all your files in several batches, each of which can be run in a different machine. Since Rector processes each file individually and independently of all other files we can easily split the list of files to process.

This PR implements two new command line options batch-index and batch-total that allow you to split the Rector run in several batches. These batches are expected to be run in parallel, not consecutevily.